### PR TITLE
Updated solidity-parser-antlr to 0.3.1 from github url version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
       "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
     },
     "solidity-parser-antlr": {
-      "version": "git+https://github.com/federicobond/solidity-parser-antlr.git#9bbf1e2e0233d5eb5881938911a38ada42a01e98"
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.3.1.tgz",
+      "integrity": "sha512-VShgeAimcWWO/xsuKcRds2wPxse8v5PZAh7kWoqDunMCwHgBHn8jtFV9GaNtnBxY4b71uOrUDovQ0+PTanyHWA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "commander": "^2.12.2",
     "fs": "0.0.1-security",
-    "solidity-parser-antlr": "https://github.com/federicobond/solidity-parser-antlr.git"
+    "solidity-parser-antlr": "^0.3.1"
   },
   "bin": {
     "solidity-graph": "./index.js"


### PR DESCRIPTION
Hi,

This tool is awesome and I've enjoyed using it to create graphs on multiple occasions. Recently there was an issue with the solidity-parser-antlr dependency (outdated). I ended up forking to get it working again and wanted to pass along this minor fix as a thank you. Cheers.

Ryan